### PR TITLE
[CHANGED] Separate types due to leftover template issues

### DIFF
--- a/tasks/config/sails-linker.js
+++ b/tasks/config/sails-linker.js
@@ -330,6 +330,18 @@ module.exports = function(grunt) {
       files: {
         'views/**/*.jade': require('../pipeline').templateFilesToInject
       }
+    },
+
+    prodTplJade: {
+      options: {
+        startTag: '// TEMPLATES',
+        endTag: '// TEMPLATES END',
+        fileTmpl: 'script(type="text/javascript", src="%s")',
+        appRoot: '.tmp/public'
+      },
+      files: {
+        'views/**/*.jade': ['.tmp/public/min/templates.min.js']
+      }
     }
   });
 

--- a/tasks/config/uglify.js
+++ b/tasks/config/uglify.js
@@ -12,14 +12,16 @@
 module.exports = function(grunt) {
 
   grunt.config.set('uglify', {
-    // dependencies: {
-    //   src: ['.tmp/public/concat/dependencies.js'],
-    //   dest: '.tmp/public/min/dependencies.min.js'
-    // },
+    dependencies: {
+      src: ['.tmp/public/concat/dependencies.js'],
+      dest: '.tmp/public/min/dependencies.min.js'
+    },
+    templates: {
+      src: ['.tmp/public/concat/templates.js'],
+      dest: ['.tmp/public/min/templates.min.js']
+    },
     js: {
-      src: ['.tmp/public/concat/dependencies.js',
-            '.tmp/public/concat/templates.js',
-            '.tmp/public/concat/production.js'],
+      src: ['.tmp/public/concat/production.js'],
       dest: '.tmp/public/min/production.min.js'
     }
   });

--- a/tasks/register/linkAssetsBuildProd.js
+++ b/tasks/register/linkAssetsBuildProd.js
@@ -15,9 +15,9 @@ module.exports = function(grunt) {
     'sails-linker:prodJsRelative',
     'sails-linker:prodStylesRelative',
     'sails-linker:devTpl',
-    // 'sails-linker:prodDependenciesJsRelativeJade',
+    'sails-linker:prodDependenciesJsRelativeJade',
     'sails-linker:prodJsRelativeJade',
     'sails-linker:prodStylesRelativeJade',
-    'sails-linker:devTplJade'
+    'sails-linker:prodTplJade'
   ]);
 };

--- a/tasks/register/prod.js
+++ b/tasks/register/prod.js
@@ -20,9 +20,9 @@ module.exports = function(grunt) {
     'sails-linker:prodJs',
     'sails-linker:prodStyles',
     'sails-linker:devTpl',
-    // 'sails-linker:prodDependenciesJsJade',
+    'sails-linker:prodDependenciesJsJade',
     'sails-linker:prodJsJade',
     'sails-linker:prodStylesJade',
-    'sails-linker:devTplJade'
+    'sails-linker:prodTplJade'
   ]);
 };


### PR DESCRIPTION
Since script tags are left in the jade file it is better to separate
everything for minifying so not have redundant imports.

All dependencies,templates, and rest of js files were put into
production js. However the jade template still had script tags from
development. Sails does not seem to delete those. Though I guess a
production linker could be created to place an empty string for
dependencies and templates instead…
